### PR TITLE
fix: use non-deprecated import for octokit

### DIFF
--- a/src/build-squash-commit.js
+++ b/src/build-squash-commit.js
@@ -1,5 +1,5 @@
 const execa = require('execa');
-const Octokit = require('@octokit/rest');
+const { Octokit } = require('@octokit/rest');
 const hostedGitInfo = require('hosted-git-info');
 const { version } = require('../package.json');
 const { getReleaseConfig } = require('./utils');


### PR DESCRIPTION
Noticed this message in CI:

```
[@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead
```