### PR TITLE
feat: make module public

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Mixmax, Inc
+Copyright (c) 2020 Mixmax, Inc
 
 Copyright (c) 2016 - 2019 Mario Nebl where applicable
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/mixmaxhq/commitlint-jenkins.git"
   },
-  "author": "Eli Skeggs <eli@mixmax.com> (https://mixmax.com)",
+  "author": "Mixmax <hello@mixmax.com> (https://mixmax.com)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mixmaxhq/commitlint-jenkins/issues"
@@ -61,6 +61,6 @@
     "manualPublishMessage": "This repository is configured to use semantic-release for its releases. Please do not release manually.\n"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
Per https://mixmaxhq.atlassian.net/browse/CORE-3434

#### Changes Made
Makes this module public.

#### Potential Risks
That there's a company-internal code that we do not want to share. Unlikely, as this is just CI tooling.

#### Test Plan
- [ ] Without being authenticated to npm (I'm using a bare ec2 instance to test), run `npm i @mixmaxhq/commitlint-jenkins`. It should install.

#### Checklist
- [ ] I've increased test coverage
- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
